### PR TITLE
code typo error in video_tutorial_notes

### DIFF
--- a/egghead.io_video_tutorial_notes.md
+++ b/egghead.io_video_tutorial_notes.md
@@ -353,7 +353,7 @@ const createStore = (reducer) => {
     listeners.forEach(listener => listener());
   };
   const subscribe = (listener) => {
-    listeners.push(listeners);
+    listeners.push(listener);
     return () => { // removing the listener from the array to unsubscribe listener
       listeners = listeners.filter(l => l !== listener);
     };


### PR DESCRIPTION
In file egghead.io_video_tutorial_notes.md, chapter: 7. Implementing Store from Scratch instead of `listeners.push(listeners);` should be `listeners.push(listener);`
