### PR TITLE
Corrected 'Go shopping' id to 1.

### DIFF
--- a/egghead.io_video_tutorial_notes.md
+++ b/egghead.io_video_tutorial_notes.md
@@ -1307,7 +1307,7 @@ console.log('--------------');
 console.log('Dispatching ADD_TODO.'); // second todo
 store.dispatch({
   type: 'ADD_TODO',
-  id: 0,
+  id: 1,
   text: 'Go shopping'
 });
 

--- a/index.html
+++ b/index.html
@@ -309,7 +309,7 @@ console.log('--------------');
 console.log('Dispatching ADD_TODO.'); // second todo
 store.dispatch({
   type: 'ADD_TODO',
-  id: 0,
+  id: 1,
   text: 'Go shopping'
 });
 


### PR DESCRIPTION
### Description

The current version has `id: 0` for the 'Go shopping' task in Video 14. I believe this should be `id: 1`, otherwise there will be two `id: 0` todos (one for 'Learn Redux' and another for 'Go shopping'). 
### Fix

I have corrected this in `index.html` and `egghead.io_video_tutorial_notes.md`.
### Remaining fixes

I am not knowledgeable enough about git/github to make these changes to all the intermediate commits that you link in the `egghead.io_video_tutorial_notes.md` file. Also, the image on line 1333 of `egghead.io_video_tutorial_notes.md` shows `id: 0` for 'Go shopping'.

Thanks
