### PR TITLE
One tiny error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ as a function which gets applied to the existing store and returns a new version
 
 > See: https://en.wikipedia.org/wiki/Immutable_object
 
-#### 3. Changes are made Using *Pure Functions*
+#### 3. Changes are made Using *Pure Functions*
 
 To change the state tree we use "*actions*" called "*reducers*",
 these are simple functions which perform a *single* action.


### PR DESCRIPTION
The whitespace ` ` character in headings like `#### ` seems to sometimes be invalid. Not sure if this is an encoding issues or what. It might be worth investigating to see if Github Flavored Markdown will support these cases. Definitely odd!


P.S. this might be a contender for the smallest pull request of all time.